### PR TITLE
if :timestamp => true AND :on_duplicate_key_update is present it will get an "column count doesn't match" error

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -333,13 +333,15 @@ class ActiveRecord::Base
           end
 
           if supports_on_duplicate_key_update?
-            case options[:on_duplicate_key_update]
-            when Array
-              options[:on_duplicate_key_update] << key.to_sym
-            when Hash
-              options[:on_duplicate_key_update][key.to_sym] = key.to_sym
-            else
-              options[:on_duplicate_key_update] = [ key.to_sym ]
+            unless column_names.any?{|cn| cn.to_sym == key.to_sym}
+              case options[:on_duplicate_key_update]
+              when Array
+                options[:on_duplicate_key_update] << key.to_sym
+              when Hash
+                options[:on_duplicate_key_update][key.to_sym] = key.to_sym
+              else
+                options[:on_duplicate_key_update] = [ key.to_sym ]
+              end
             end
           end
         end


### PR DESCRIPTION
if :timestamp => true and using the :on_duplicate_key_update option it will produce the error below

``` console
Mysql2::Error: Column count doesn't match value count at row 1: INSERT INTO (OTHERCOLUMNS,

`created_at`,`updated_at`,`updated_at`)

 VALUES .....(VALUESHERE) ON DUPLICATE KEY UPDATE OTHERDUPLICATESTUFFHERE, 

`table_name`.`created_at`=VALUES(`created_at`),`table_name`.`updated_at`=VALUES(`updated_at`),`table_name`.`updated_at`=VALUES(`updated_at`)
```

it will do a double `updated_at` in the columns and the on duplicate key update section.
This pull request fixes this
